### PR TITLE
Add Support for Byte Size and Time Duration Parsing with Enhanced Aggregation Capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ These directives are currently available:
 | [Parse XML To JSON](wrangler-docs/directives/parse-xml-to-json.md)              | Parses an XML document into a JSON structure                     |
 | [Parse as Currency](wrangler-docs/directives/parse-as-currency.md)              | Parses a string representation of currency into a number.        |
 | [Parse as Datetime](wrangler-docs/directives/parse-as-datetime.md)              | Parses strings with datetime values to CDAP datetime type        |
+| [Parse as ByteSize](wrangler-docs/directives/parse-as-bytesize.md)              | Parses a string representation of byte size into a numeric value |
+| [Parse as TimeDuration](wrangler-docs/directives/parse-as-timeduration.md)      | Parses a string representation of time duration into a numeric value |
 | **Output Formatters**                                                  |                                                                  |
 | [Write as CSV](wrangler-docs/directives/write-as-csv.md)                        | Converts a record into CSV format                                |
 | [Write as JSON](wrangler-docs/directives/write-as-json-map.md)                  | Converts the record into a JSON map                              |

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,10 +1,29 @@
-package io.cdap.wrangler.api.parser;
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 
-import java.util.Locale;
+package io.cdap.wrangler.api.parser;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import java.util.Locale;
+
+/**
+ * Represents a token for byte size values with units (e.g., KB, MB, GB).
+ */
 public class ByteSize implements Token {
 
     private Double bytes;
@@ -35,7 +54,7 @@ public class ByteSize implements Token {
      * @return Byte size in long.
      */
     public double getBytes() {
-        return (double) this.bytes;
+        return this.bytes;
     }
 
     /**
@@ -52,29 +71,36 @@ public class ByteSize implements Token {
     /**
      * Parses the input string and converts it to bytes.
      *
-     * @param input The input byte size string.
+     * @param value The input byte size string.
      * @return The size in bytes.
      * @throws IllegalArgumentException if input is not a valid byte size
      * string.
      */
     private Double parseBytes(String value) {
         String normalize = value.trim().toLowerCase(Locale.ENGLISH);
-        double value_double = Double.parseDouble(normalize.replaceAll("[^0-9.]", ""));
+        double valueDouble = Double.parseDouble(normalize.replaceAll("[^0-9.-]", ""));
+        String unit = normalize.replaceAll("[^a-zA-Z]+", "");
+        System.out.println(unit);
 
-        if (normalize.endsWith("bytes")) {
-            return (double) (value_double);
-        } else if (normalize.endsWith("kb")) {
-            return (double) (value_double * 1024);
-        } else if (normalize.endsWith("mb")) {
-            return (double) (value_double * 1024 * 1024);
-        } else if (normalize.endsWith("gb")) {
-            return (double) (value_double * 1024 * 1024 * 1024);
-        } else if (normalize.endsWith("tb")) {
-            return (double) (value_double * 1024 * 1024 * 1024 * 1024);
+        if (valueDouble < 0) {
+            throw new IllegalArgumentException("Negative byte size values are not allowed: " + value);
+        }
+
+        if (unit.equals("bytes")) {
+            return valueDouble;
+        } else if (unit.equals("b")) {
+            return valueDouble;
+        } else if (unit.equals("kb")) {
+            return valueDouble * 1024;
+        } else if (unit.equals("mb")) {
+            return valueDouble * 1024 * 1024;
+        } else if (unit.equals("gb")) {
+            return valueDouble * 1024 * 1024 * 1024;
+        } else if (unit.equals("tb")) {
+            return valueDouble * 1024 * 1024 * 1024 * 1024;
         } else {
             throw new IllegalArgumentException("Unsupported byte unit in: " + value);
         }
-
     }
 
     /**
@@ -86,7 +112,6 @@ public class ByteSize implements Token {
      */
     @Override
     public JsonElement toJson() {
-
         JsonObject object = new JsonObject();
         object.addProperty("type", TokenType.BYTE_SIZE.name());
         object.addProperty("value", this.bytes);

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,18 +1,94 @@
 package io.cdap.wrangler.api.parser;
 
+import java.util.Locale;
+
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
 
 public class ByteSize implements Token {
 
-    private long bytes;
+    private Double bytes;
 
-    public ByteSize()
+   /**
+   * Constructs a ByteSize token.
+   *
+   * @param value The string representation of byte size (e.g., "10KB").
+   */
+    public ByteSize(String value){
+        this.bytes = parseBytes(value);
+    }
+   
+   /**
+   * Returns the value of this {@code ByteSize} object as a {@code Double}
+   * representing the size in bytes.
+   *
+   * @return the byte size value of this object.
+   */
+    @Override  
+    public Double value() {
+        return getBytes();
+    }
 
 
+    /**
+   * Returns the value in bytes.
+   *
+   * @return Byte size in long.
+   */
+    public double getBytes() {
+        return (double) this.bytes;
+    }
+
+   /**
+   * Returns the type of this {@code BYTE_SIZE} object as a {@code TokenType}
+   * enum.
+   *
+   * @return the enumerated {@code TokenType} of this object.
+   */
+    @Override
+    public TokenType type() {
+        return TokenType.BYTE_SIZE;
+    }
+
+    /**
+   * Parses the input string and converts it to bytes.
+   *
+   * @param input The input byte size string.
+   * @return The size in bytes.
+   * @throws IllegalArgumentException if input is not a valid byte size string.
+   */
+
+    private Double parseBytes(String value) {
+        String normalize = value.trim().toLowerCase(Locale.ENGLISH);
+        double value_double = Double.parseDouble(normalize.replaceAll("[^0-9.]", ""));
+
+        if (normalize.endsWith("kb")) {
+            return (double) (value_double * 1024);
+        }else if (normalize.endsWith("mb")) {
+            return (double) (value_double * 1024 * 1024);
+        } else if (normalize.endsWith("gb")) {
+            return (double) (value_double * 1024 * 1024 * 1024);
+        }  else if (normalize.endsWith("tb")) {
+            return (double) (value_double  * 1024 * 1024 * 1024 * 1024);
+        } else {
+            throw new IllegalArgumentException("Unsupported byte unit in: " + value);
+        }
+
+    }
 
 
+  /**
+   * Returns the members of this {@code BYTE_SIZE} object as a {@code JsonElement}.
+   *
+   * @return Json representation of this {@code BYTE_SIZE} object as {@code JsonElement}
+   */
     @Override
     public JsonElement toJson() {
 
+        JsonObject object = new JsonObject();
+        object.addProperty("type", TokenType.BYTE_SIZE.name());
+        object.addProperty("value", this.bytes);
+        return object;
     }
 } 

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -5,84 +5,85 @@ import java.util.Locale;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
-
 public class ByteSize implements Token {
 
     private Double bytes;
 
-   /**
-   * Constructs a ByteSize token.
-   *
-   * @param value The string representation of byte size (e.g., "10KB").
-   */
-    public ByteSize(String value){
+    /**
+     * Constructs a ByteSize token.
+     *
+     * @param value The string representation of byte size (e.g., "10KB").
+     */
+    public ByteSize(String value) {
         this.bytes = parseBytes(value);
     }
-   
-   /**
-   * Returns the value of this {@code ByteSize} object as a {@code Double}
-   * representing the size in bytes.
-   *
-   * @return the byte size value of this object.
-   */
-    @Override  
+
+    /**
+     * Returns the value of this {@code ByteSize} object as a {@code Double}
+     * representing the size in bytes.
+     *
+     * @return the byte size value of this object.
+     */
+    @Override
     public Double value() {
         return getBytes();
     }
 
-
     /**
-   * Returns the value in bytes.
-   *
-   * @return Byte size in long.
-   */
+     * Returns the value in bytes.
+     *
+     * @return Byte size in long.
+     */
     public double getBytes() {
         return (double) this.bytes;
     }
 
-   /**
-   * Returns the type of this {@code BYTE_SIZE} object as a {@code TokenType}
-   * enum.
-   *
-   * @return the enumerated {@code TokenType} of this object.
-   */
+    /**
+     * Returns the type of this {@code BYTE_SIZE} object as a {@code TokenType}
+     * enum.
+     *
+     * @return the enumerated {@code TokenType} of this object.
+     */
     @Override
     public TokenType type() {
         return TokenType.BYTE_SIZE;
     }
 
     /**
-   * Parses the input string and converts it to bytes.
-   *
-   * @param input The input byte size string.
-   * @return The size in bytes.
-   * @throws IllegalArgumentException if input is not a valid byte size string.
-   */
-
+     * Parses the input string and converts it to bytes.
+     *
+     * @param input The input byte size string.
+     * @return The size in bytes.
+     * @throws IllegalArgumentException if input is not a valid byte size
+     * string.
+     */
     private Double parseBytes(String value) {
         String normalize = value.trim().toLowerCase(Locale.ENGLISH);
         double value_double = Double.parseDouble(normalize.replaceAll("[^0-9.]", ""));
 
-        if (normalize.endsWith("kb")) {
+        if (normalize.endsWith("bytes")) {
+            return (double) (value_double);
+        } else if (normalize.endsWith("kb")) {
             return (double) (value_double * 1024);
-        }else if (normalize.endsWith("mb")) {
+        } else if (normalize.endsWith("mb")) {
             return (double) (value_double * 1024 * 1024);
         } else if (normalize.endsWith("gb")) {
             return (double) (value_double * 1024 * 1024 * 1024);
-        }  else if (normalize.endsWith("tb")) {
-            return (double) (value_double  * 1024 * 1024 * 1024 * 1024);
+        } else if (normalize.endsWith("tb")) {
+            return (double) (value_double * 1024 * 1024 * 1024 * 1024);
         } else {
             throw new IllegalArgumentException("Unsupported byte unit in: " + value);
         }
 
     }
 
-
-  /**
-   * Returns the members of this {@code BYTE_SIZE} object as a {@code JsonElement}.
-   *
-   * @return Json representation of this {@code BYTE_SIZE} object as {@code JsonElement}
-   */
+    /**
+     * Returns the members of this {@code BYTE_SIZE} object as a
+     * {@code JsonElement}.
+     *
+     * @return Json representation of this {@code BYTE_SIZE} object as
+     * {@code JsonElement}
+     */
     @Override
     public JsonElement toJson() {
 
@@ -91,4 +92,4 @@ public class ByteSize implements Token {
         object.addProperty("value", this.bytes);
         return object;
     }
-} 
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,18 @@
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+
+public class ByteSize implements Token {
+
+    private long bytes;
+
+    public ByteSize()
+
+
+
+
+    @Override
+    public JsonElement toJson() {
+
+    }
+} 

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,10 +1,29 @@
-package io.cdap.wrangler.api.parser;
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 
-import java.util.Locale;
+package io.cdap.wrangler.api.parser;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import java.util.Locale;
+
+/**
+ * Represents a token for time duration values with units (e.g., ms, s, m, h).
+ */
 public class TimeDuration implements Token {
 
     private Double time;
@@ -35,7 +54,7 @@ public class TimeDuration implements Token {
      * @return time value in double.
      */
     public double getTime() {
-        return (double) this.time;
+        return this.time;
     }
 
     /**
@@ -52,27 +71,39 @@ public class TimeDuration implements Token {
     /**
      * Parses the input string and converts it to milliseconds.
      *
-     * @param input The input time value string.
+     * @param value The input time duration string.
      * @return The time in milliseconds.
-     * @throws IllegalArgumentException if input is not a valid time unit
+     * @throws IllegalArgumentException if input is not a valid time duration
      * string.
      */
     private Double parseMilliSeconds(String value) {
         String normalize = value.trim().toLowerCase(Locale.ENGLISH);
-        double value_double = Double.parseDouble(normalize.replaceAll("[^0-9.]", ""));
+        double valueDouble = Double.parseDouble(normalize.replaceAll("[^0-9.\\-]", ""));
+        String unit = normalize.replaceAll("[^a-zA-Z]+", "");
+        if (valueDouble < 0) {
+            throw new IllegalArgumentException("Negative time values are not allowed: " + value);
+        }
 
-        if (normalize.endsWith("ms")) {
-            return (double) (value_double);
-        } else if (normalize.endsWith("s") || normalize.endsWith("sec") || normalize.endsWith("secs")) {
-            return (double) (value_double * 1000);
-        } else if (normalize.endsWith("m") || normalize.endsWith("min") || normalize.endsWith("mins")) {
-            return (double) (value_double * 60 * 1000);
-        } else if (normalize.endsWith("h") || normalize.endsWith("hr") || normalize.endsWith("hour") || normalize.endsWith("hours")) {
-            return (double) (value_double * 60 * 60 * 1000);
+        if (unit.equals("ms")) {
+            return valueDouble;
+        } else if (unit.equals("s") 
+                || unit.equals("sec") 
+                || unit.equals("secs")) {
+            return valueDouble * 1000;
+        } else if (unit.equals("m") || unit.equals("min")) {
+            return valueDouble * 1000 * 60;
+        } else if (unit.equals("hours") || normalize.contains("hours")) { // Adjusted condition
+            System.out.println(valueDouble + " valueDouble");
+            return valueDouble * 1000 * 60 * 60;
+        } else if (unit.equals("hour")) {
+            return valueDouble * 1000 * 60 * 60;
+        } else if (unit.equals("hr")) {
+            return valueDouble * 1000 * 60 * 60;
+        } else if (unit.equals("h")) {
+            return valueDouble * 1000 * 60 * 60;
         } else {
             throw new IllegalArgumentException("Unsupported time unit in: " + value);
         }
-
     }
 
     /**
@@ -84,7 +115,6 @@ public class TimeDuration implements Token {
      */
     @Override
     public JsonElement toJson() {
-
         JsonObject object = new JsonObject();
         object.addProperty("type", TokenType.TIME_DURATION.name());
         object.addProperty("value", this.time);

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,93 @@
+package io.cdap.wrangler.api.parser;
+
+import java.util.Locale;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+public class TimeDuration implements Token {
+
+    private Double time;
+
+    /**
+     * Constructs a TimeDuration token.
+     *
+     * @param value The string representation of time value (e.g., "10sec").
+     */
+    public TimeDuration(String value) {
+        this.time = parseMilliSeconds(value);
+    }
+
+    /**
+     * Returns the value of this {@code TIME_DURATION} object as a
+     * {@code Double} representing the time in milliseconds.
+     *
+     * @return the time (milliseconds) value of this object.
+     */
+    @Override
+    public Double value() {
+        return getTime();
+    }
+
+    /**
+     * Returns the value in milliseconds.
+     *
+     * @return time value in double.
+     */
+    public double getTime() {
+        return (double) this.time;
+    }
+
+    /**
+     * Returns the type of this {@code TIME_DURATION} object as a
+     * {@code TokenType} enum.
+     *
+     * @return the enumerated {@code TokenType} of this object.
+     */
+    @Override
+    public TokenType type() {
+        return TokenType.TIME_DURATION;
+    }
+
+    /**
+     * Parses the input string and converts it to milliseconds.
+     *
+     * @param input The input time value string.
+     * @return The time in milliseconds.
+     * @throws IllegalArgumentException if input is not a valid time unit
+     * string.
+     */
+    private Double parseMilliSeconds(String value) {
+        String normalize = value.trim().toLowerCase(Locale.ENGLISH);
+        double value_double = Double.parseDouble(normalize.replaceAll("[^0-9.]", ""));
+
+        if (normalize.endsWith("ms")) {
+            return (double) (value_double);
+        } else if (normalize.endsWith("s") || normalize.endsWith("sec") || normalize.endsWith("secs")) {
+            return (double) (value_double * 1000);
+        } else if (normalize.endsWith("m") || normalize.endsWith("min") || normalize.endsWith("mins")) {
+            return (double) (value_double * 60 * 1000);
+        } else if (normalize.endsWith("h") || normalize.endsWith("hr") || normalize.endsWith("hour") || normalize.endsWith("hours")) {
+            return (double) (value_double * 60 * 60 * 1000);
+        } else {
+            throw new IllegalArgumentException("Unsupported time unit in: " + value);
+        }
+
+    }
+
+    /**
+     * Returns the members of this {@code TIME_DURATION} object as a
+     * {@code JsonElement}.
+     *
+     * @return Json representation of this {@code TIME_DURATION} object as
+     * {@code JsonElement}
+     */
+    @Override
+    public JsonElement toJson() {
+
+        JsonObject object = new JsonObject();
+        object.addProperty("type", TokenType.TIME_DURATION.name());
+        object.addProperty("value", this.time);
+        return object;
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -152,5 +152,20 @@ public enum TokenType implements Serializable {
    * Represents the enumerated type for the object of type {@code String} with restrictions
    * on characters that can be present in a string.
    */
-  IDENTIFIER
+  IDENTIFIER,
+
+  /**
+   * Represents the enumerated type for the object of type {@code ByteSize}.
+   * This type is associated with byte size values with units (KB, MB, GB, TB).
+   * E.g. "1.5MB", "500KB", "2.1GB"
+  */
+  BYTE_SIZE,
+
+  /**
+   * Represents the enumerated type for the object of type {@code TimeDuration}.
+   * This type is associated with time duration values with units (ms, s, m, h, d).
+   * E.g. "500ms", "1.5s", "2h"
+  */
+  TIME_DURATION,
+
 }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/UsageDefinition.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/UsageDefinition.java
@@ -126,6 +126,10 @@ public final class UsageDefinition implements Serializable {
           sb.append("prop:{key:value,[key:value]*");
         } else if (token.type().equals(TokenType.RANGES)) {
           sb.append("start:end=[bool|text|numeric][,start:end=[bool|text|numeric]*");
+        } else if (token.type().equals(TokenType.BYTE_SIZE)) {
+          sb.append(token.name()).append(" ([FLOAT|INT][KB|MB|GB|TB])");
+        } else if (token.type().equals(TokenType.TIME_DURATION)) {
+          sb.append(token.name()).append(" ([FLOAT|INT][ms|s|m|h])");
         }
       }
 

--- a/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/ByteSizeTest.java
+++ b/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/ByteSizeTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * @author tomar-ayush
+ * Created on: 2025-04-11 15:16:14
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ByteSize}.
+ */
+public class ByteSizeTest {
+
+  @Test
+  public void testValidByteSizes() {
+    Assert.assertEquals(1024, new ByteSize("1KB").getBytes(), 0.001);
+    Assert.assertEquals(2048, new ByteSize("2kb").getBytes(), 0.001); // case-insensitive
+    Assert.assertEquals(1048576, new ByteSize("1MB").getBytes(), 0.001);
+    Assert.assertEquals(1073741824L, new ByteSize("1GB").getBytes(), 0.001);
+    Assert.assertEquals(1099511627776L, new ByteSize("1TB").getBytes(), 0.001);
+  }
+
+  @Test
+  public void testDecimalByteSizes() {
+    Assert.assertEquals(1536, new ByteSize("1.5KB").getBytes(), 0.001);
+    Assert.assertEquals(1572864, new ByteSize("1.5MB").getBytes(), 0.001);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidUnit() {
+    new ByteSize("50XY");
+  }
+
+  @Test(expected = NumberFormatException.class)
+  public void testMalformedNumber() {
+    new ByteSize("abcMB");
+  }
+
+  @Test
+  public void testWhitespaceHandling() {
+    Assert.assertEquals(1024, new ByteSize(" 1KB ").getBytes(), 0.001);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+    public void testNegativeValue() {
+      new ByteSize("-1KB");
+  }
+}

--- a/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/ByteSizeTest.java
+++ b/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/ByteSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 Cask Data, Inc.
+ * Copyright © 2017-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -12,9 +12,6 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- *
- * @author tomar-ayush
- * Created on: 2025-04-11 15:16:14
  */
 
 package io.cdap.wrangler.api.parser;

--- a/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/TimeDurationTest.java
+++ b/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/TimeDurationTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * @author tomar-ayush
+ * Created on: 2025-04-11 14:46:08
+ */
+package io.cdap.wrangler.api.parser;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class TimeDurationTest {
+
+    @Test
+    public void testValidDurations() {
+        Assert.assertEquals(1000.0, new TimeDuration("1s").getTime(), 0.01);
+        Assert.assertEquals(1000.0, new TimeDuration("1sec").getTime(), 0.01);
+        Assert.assertEquals(1000.0, new TimeDuration("1secs").getTime(), 0.01);
+        Assert.assertEquals(100.0, new TimeDuration("100ms").getTime(), 0.01);
+        Assert.assertEquals(60000.0, new TimeDuration("1m").getTime(), 0.01);
+        Assert.assertEquals(60000.0, new TimeDuration("1min").getTime(), 0.01);
+        Assert.assertEquals(3600000.0, new TimeDuration("1h").getTime(), 0.01);
+        Assert.assertEquals(3600000.0, new TimeDuration("1hr").getTime(), 0.01);
+        Assert.assertEquals(3600000.0, new TimeDuration("1hour").getTime(), 0.01);
+        Assert.assertEquals(7200000.0, new TimeDuration("2hours").getTime(), 0.01);
+    }
+
+    @Test
+    public void testDecimalDurations() {
+        Assert.assertEquals(1500.0, new TimeDuration("1.5s").getTime(), 0.01);
+        Assert.assertEquals(90000.0, new TimeDuration("1.5min").getTime(), 0.01);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidFormat() {
+        new TimeDuration("invalid");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidUnit() {
+        new TimeDuration("1d");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNegativeValue() {
+        new TimeDuration("-1s");
+    }
+}

--- a/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/TimeDurationTest.java
+++ b/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/TimeDurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 Cask Data, Inc.
+ * Copyright © 2017-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -12,10 +12,8 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- *
- * @author tomar-ayush
- * Created on: 2025-04-11 14:46:08
  */
+
 package io.cdap.wrangler.api.parser;
 
 import org.junit.Assert;

--- a/wrangler-core/pom.xml
+++ b/wrangler-core/pom.xml
@@ -358,6 +358,13 @@
           </items>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -140,7 +140,7 @@ numberRange
  ;
 
 value
- : String | Number | Column | Bool | BYTE_SIZE | TIME_DURATION;
+ : String | Number | Column | Bool | BYTE_SIZE | TIME_DURATION
  ;
 
 ecommand
@@ -281,11 +281,9 @@ EscapeSequence
    ;
 
 BYTE_SIZE 
-    : (FLOAT | INT) BYTE_UNIT; 
+    : (FLOAT | Int) BYTE_UNIT; 
 
- /* [INT]+ ('.'[INT]+)? */ 
-
-TIME_DURATION: (FLOAT | INT) TIME_UNIT;
+TIME_DURATION: (FLOAT | Int) TIME_UNIT;
 
 fragment BYTE_UNIT 
   : ('K' | 'k') ('B' | 'b')?

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -288,10 +288,10 @@ BYTE_SIZE
 TIME_DURATION: (FLOAT | INT) TIME_UNIT;
 
 fragment BYTE_UNIT 
-  : ('K' | 'k') ('B' | 'b' | 'i' | 'I')?
-  | ('M' | 'm') ('B' | 'b' | 'i' | 'I')? 
-  | ('G' | 'g') ('B' | 'b' | 'i' | 'I')? 
-  | ('T' | 't') ('B' | 'b' | 'i' | 'I')?   
+  : ('K' | 'k') ('B' | 'b')?
+  | ('M' | 'm') ('B' | 'b')? 
+  | ('G' | 'g') ('B' | 'b')? 
+  | ('T' | 't') ('B' | 'b')?   
 ;
 
 fragment TIME_UNIT: 'ms' | 's' | 'sec' | 'secs' | 'm' | 'min' | 'h' | 'hr' | 'hour' | 'hours';

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -140,7 +140,7 @@ numberRange
  ;
 
 value
- : String | Number | Column | Bool
+ : String | Number | Column | Bool | BYTE_SIZE | TIME_DURATION;
  ;
 
 ecommand
@@ -280,6 +280,23 @@ EscapeSequence
    |   OctalEscape
    ;
 
+BYTE_SIZE 
+    : (FLOAT | INT) BYTE_UNIT; 
+
+ /* [INT]+ ('.'[INT]+)? */ 
+
+TIME_DURATION: (FLOAT | INT) TIME_UNIT;
+
+fragment BYTE_UNIT 
+  : ('K' | 'k') ('B' | 'b' | 'i' | 'I')?
+  | ('M' | 'm') ('B' | 'b' | 'i' | 'I')? 
+  | ('G' | 'g') ('B' | 'b' | 'i' | 'I')? 
+  | ('T' | 't') ('B' | 'b' | 'i' | 'I')?   
+;
+
+fragment TIME_UNIT: 'ms' | 's' | 'sec' | 'secs' | 'm' | 'min' | 'h' | 'hr' | 'hour' | 'hours';
+
+
 fragment
 OctalEscape
    :   '\\' ('0'..'3') ('0'..'7') ('0'..'7')
@@ -307,6 +324,10 @@ fragment Int
  : '-'? [1-9] Digit* [L]*
  | '0'
  ;
+
+fragment FLOAT   
+  : [0-9]+ '.' [0-9]+   
+  ;  
 
 fragment Digit
  : [0-9]

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
@@ -1,0 +1,128 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.directives.aggregates;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.DirectiveExecutionException;
+import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.annotations.Categories;
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.Text;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+import java.util.ArrayList;
+import java.util.List;
+/**
+ * Directive for aggregating statistics.
+ */
+@Categories(categories = { "data-aggregation"})
+
+public class AggregateStats implements Directive {
+    public static final String NAME = "aggregate-stats";
+    private String byteCol;
+    private String timeCol;
+    private String outputSizeCol;
+    private String outputTimeCol;
+    private double totalBytes = 0.0;
+    private double totalTimeMs = 0.0;
+    private int count = 0;
+
+    @Override
+    public UsageDefinition define() {
+        UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
+        builder.define("byteCol", TokenType.COLUMN_NAME);
+        builder.define("timeCol", TokenType.COLUMN_NAME);
+        builder.define("outputSizeCol", TokenType.TEXT);
+        builder.define("outputTimeCol", TokenType.TEXT);
+        return builder.build();
+    }
+
+    @Override
+    public void initialize(Arguments args) throws DirectiveParseException {
+        byteCol = ((ColumnName) args.value("byteCol")).value();
+        timeCol = ((ColumnName) args.value("timeCol")).value();
+        outputSizeCol = ((Text) args.value("outputSizeCol")).value();
+        outputTimeCol = ((Text) args.value("outputTimeCol")).value();
+    }
+
+    @Override
+    public List<Row> execute(List<Row> rows, ExecutorContext ctx) throws DirectiveExecutionException {
+        try {
+            for (Row row : rows) {
+                if (row.find(byteCol) != -1 && row.find(timeCol) != -1) {
+                    String byteVal = row.getValue(byteCol).toString();
+                    String timeVal = row.getValue(timeCol).toString();
+                    
+                    // Use ByteSize and TimeDuration classes for parsing
+                    ByteSize byteSize = new ByteSize(byteVal);
+                    TimeDuration duration = new TimeDuration(timeVal);
+                    
+                    totalBytes += byteSize.getBytes();
+                    totalTimeMs += duration.getTime();
+                    count++;
+                }
+            }
+
+            if (count == 0) {
+                return new ArrayList<>(); 
+            }
+
+            List<Row> results = new ArrayList<>();
+            Row result = new Row();
+            
+            // Convert bytes to MB and milliseconds to seconds
+            result.add(outputSizeCol, totalBytes / (1024.0 * 1024.0));
+            result.add(outputTimeCol, totalTimeMs / 1000.0);
+            
+            results.add(result);
+            return results;
+            
+        } catch (Exception e) {
+            throw new DirectiveExecutionException(
+                String.format("Error aggregating stats: %s", e.getMessage())
+            );
+        }
+    }
+
+    // @Override
+    public Schema getOutputSchema(Schema inputSchema) {
+        List<Schema.Field> fields = new ArrayList<>();
+        fields.add(Schema.Field.of(outputSizeCol, Schema.of(Schema.Type.DOUBLE)));
+        fields.add(Schema.Field.of(outputTimeCol, Schema.of(Schema.Type.DOUBLE)));
+        return Schema.recordOf("aggregate-stats", fields);
+    }
+
+    @Override
+    public void destroy() {
+      // Reset all accumulated values
+      totalBytes = 0.0;
+      totalTimeMs = 0.0;
+      count = 0;
+
+      // Clear column references
+      byteCol = null;
+      timeCol = null;
+      outputSizeCol = null;
+      outputTimeCol = null;
+    }
+}

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
@@ -47,6 +47,11 @@ public class AggregateStats implements Directive {
     private double totalTimeMs = 0.0;
     private int count = 0;
 
+    /**
+     * Defines the usage of the directive, specifying the required arguments.
+     *
+     * @return UsageDefinition object containing the directive's argument definitions.
+     */
     @Override
     public UsageDefinition define() {
         UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
@@ -57,6 +62,12 @@ public class AggregateStats implements Directive {
         return builder.build();
     }
 
+    /**
+     * Initializes the directive with the provided arguments.
+     *
+     * @param args Arguments object containing the directive's parameters.
+     * @throws DirectiveParseException if there is an error parsing the arguments.
+     */
     @Override
     public void initialize(Arguments args) throws DirectiveParseException {
         byteCol = ((ColumnName) args.value("byteCol")).value();
@@ -65,6 +76,14 @@ public class AggregateStats implements Directive {
         outputTimeCol = ((Text) args.value("outputTimeCol")).value();
     }
 
+    /**
+     * Executes the directive on a list of rows, aggregating statistics based on the specified columns.
+     *
+     * @param rows List of Row objects to process.
+     * @param ctx ExecutorContext providing execution context information.
+     * @return List of Row objects containing the aggregated results.
+     * @throws DirectiveExecutionException if there is an error during execution.
+     */
     @Override
     public List<Row> execute(List<Row> rows, ExecutorContext ctx) throws DirectiveExecutionException {
         try {
@@ -104,7 +123,12 @@ public class AggregateStats implements Directive {
         }
     }
 
-    // @Override
+    /**
+     * Provides the output schema for the directive based on the input schema.
+     *
+     * @param inputSchema Schema object representing the input schema.
+     * @return Schema object representing the output schema.
+     */
     public Schema getOutputSchema(Schema inputSchema) {
         List<Schema.Field> fields = new ArrayList<>();
         fields.add(Schema.Field.of(outputSizeCol, Schema.of(Schema.Type.DOUBLE)));
@@ -112,6 +136,9 @@ public class AggregateStats implements Directive {
         return Schema.recordOf("aggregate-stats", fields);
     }
 
+    /**
+     * Cleans up resources and resets the directive's state.
+     */
     @Override
     public void destroy() {
       // Reset all accumulated values

--- a/wrangler-core/src/main/java/io/cdap/wrangler/dq/ConvertString.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/dq/ConvertString.java
@@ -77,7 +77,7 @@ public class ConvertString {
     if (!StringUtils.isEmpty(repeatStr)) {
       removeRepeatCharPattern = Pattern.compile("(" + repeatStr + ")+");
     }
-    removeWhiteSpacesPattern = Pattern.compile("([\\s\\u0085\\p{Z}])\\1+");
+    removeWhiteSpacesPattern = Pattern.compile("([\\s\\u0085\\p{Z}\\u180E])\\1+");
   }
 
   /**

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
@@ -331,6 +331,12 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
     return new SourceInfo(lineno, column, text);
   }
   
+  /**
+   * Visits a value node in the parse tree and extracts the corresponding token.
+   *
+   * @param ctx The context of the value node in the parse tree.
+   * @return The updated RecipeSymbol.Builder after processing the value node.
+   */
   @Override
   public RecipeSymbol.Builder visitValue(DirectivesParser.ValueContext ctx) {
     if (ctx.BYTE_SIZE() != null) {

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
@@ -22,6 +22,7 @@ import io.cdap.wrangler.api.SourceInfo;
 import io.cdap.wrangler.api.Triplet;
 import io.cdap.wrangler.api.parser.Bool;
 import io.cdap.wrangler.api.parser.BoolList;
+import io.cdap.wrangler.api.parser.ByteSize;
 import io.cdap.wrangler.api.parser.ColumnName;
 import io.cdap.wrangler.api.parser.ColumnNameList;
 import io.cdap.wrangler.api.parser.DirectiveName;
@@ -33,12 +34,15 @@ import io.cdap.wrangler.api.parser.Properties;
 import io.cdap.wrangler.api.parser.Ranges;
 import io.cdap.wrangler.api.parser.Text;
 import io.cdap.wrangler.api.parser.TextList;
+import io.cdap.wrangler.api.parser.TimeDuration;
 import io.cdap.wrangler.api.parser.Token;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -325,5 +329,22 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
     int lineno = ctx.getStart().getLine();
     int column = ctx.getStart().getCharPositionInLine();
     return new SourceInfo(lineno, column, text);
+  }
+  
+  @Override
+  public RecipeSymbol.Builder visitValue(DirectivesParser.ValueContext ctx) {
+    if (ctx.BYTE_SIZE() != null) {
+        String value = ctx.BYTE_SIZE().getText();
+        builder.addToken(new ByteSize(value));
+        return builder;
+    }
+
+    if (ctx.TIME_DURATION() != null) {
+        String value = ctx.TIME_DURATION().getText();
+        builder.addToken(new TimeDuration(value));
+        return builder;
+    }
+
+    return super.visitValue(ctx);
   }
 }

--- a/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateStatsTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateStatsTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.directives.aggregates;
+
+// Reorder imports to follow checkstyle rules
+import com.google.gson.JsonElement;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.Text;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import io.cdap.wrangler.api.parser.Token;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AggregateStatsTest {
+
+  @Test
+  public void testAggregateStatsDirective() throws Exception {
+    // Step 1: Prepare input rows
+    List<Row> rows = new ArrayList<>();
+    rows.add(new Row().add("data_transfer_size", "10KB").add("response_time", "2s"));
+    rows.add(new Row().add("data_transfer_size", "5KB").add("response_time", "500ms"));
+
+    // Step 2: Create an instance of the directive
+    AggregateStats directive = new AggregateStats();
+
+    // Step 3: Manually mock Arguments
+    Arguments args = createMockArguments();
+
+    // Step 4: Initialize and execute the directive
+    directive.initialize(args);
+    List<Row> result = directive.execute(rows, null);
+
+    // Step 5: Validate output
+    Assert.assertEquals(1, result.size());
+
+    Row output = result.get(0);
+
+    // Size: 10KB + 5KB = 15KB = 15 * 1024 bytes = 15360 bytes
+    // MB = bytes / (1024 * 1024)
+    double expectedMB = 15360.0 / (1024 * 1024);
+    double actualMB = (Double) output.getValue("total_size_mb");
+
+    // Time: 2s + 500ms = 2500ms = 2.5s
+    double expectedSeconds = 2.5;
+    double actualSeconds = (Double) output.getValue("total_time_sec");
+
+    Assert.assertEquals(expectedMB, actualMB, 0.001);
+    Assert.assertEquals(expectedSeconds, actualSeconds, 0.001);
+  }
+
+  @Test
+  public void testEmptyInputRows() throws Exception {
+    List<Row> rows = new ArrayList<>();
+
+    AggregateStats directive = new AggregateStats();
+    Arguments args = createMockArguments();
+
+    directive.initialize(args);
+    List<Row> result = directive.execute(rows, null);
+
+    Assert.assertEquals(0, result.size());
+  }
+
+  @Test
+  public void testInvalidData() throws Exception {
+    List<Row> rows = new ArrayList<>();
+    rows.add(new Row().add("data_transfer_size", "invalidKB").add("response_time", "invalidTime"));
+
+    AggregateStats directive = new AggregateStats();
+    Arguments args = createMockArguments();
+
+    directive.initialize(args);
+    try {
+      directive.execute(rows, null);
+      Assert.fail("Expected an exception for invalid data");
+    } catch (Exception e) {
+      Assert.assertTrue(e.getMessage().contains("Error aggregating stats"));
+    }
+  }
+
+  @Test
+  public void testLargeData() throws Exception {
+    List<Row> rows = new ArrayList<>();
+    rows.add(new Row().add("data_transfer_size", "1024MB").add("response_time", "1h"));
+    rows.add(new Row().add("data_transfer_size", "512MB").add("response_time", "30m"));
+
+    AggregateStats directive = new AggregateStats();
+    Arguments args = createMockArguments();
+
+    directive.initialize(args);
+    List<Row> result = directive.execute(rows, null);
+
+    Assert.assertEquals(1, result.size());
+
+    Row output = result.get(0);
+
+    double expectedMB = 1536.0; // 1024MB + 512MB
+    double actualMB = (Double) output.getValue("total_size_mb");
+
+    double expectedSeconds = 5400.0; // 1h + 30m = 5400 seconds
+    double actualSeconds = (Double) output.getValue("total_time_sec");
+
+    Assert.assertEquals(expectedMB, actualMB, 0.001);
+    Assert.assertEquals(expectedSeconds, actualSeconds, 0.001);
+  }
+
+  @Test
+  public void testEdgeCases() throws Exception {
+    List<Row> rows = new ArrayList<>();
+    rows.add(new Row().add("data_transfer_size", "0KB").add("response_time", "0s"));
+
+    AggregateStats directive = new AggregateStats();
+    Arguments args = createMockArguments();
+
+    directive.initialize(args);
+    List<Row> result = directive.execute(rows, null);
+
+    Assert.assertEquals(1, result.size());
+
+    Row output = result.get(0);
+
+    double expectedMB = 0.0;
+    double actualMB = (Double) output.getValue("total_size_mb");
+
+    double expectedSeconds = 0.0;
+    double actualSeconds = (Double) output.getValue("total_time_sec");
+
+    Assert.assertEquals(expectedMB, actualMB, 0.001);
+    Assert.assertEquals(expectedSeconds, actualSeconds, 0.001);
+  }
+
+  private Arguments createMockArguments() {
+    return new Arguments() {
+      @SuppressWarnings("unchecked")
+      @Override
+      public <T extends Token> T value(String name) {
+        switch (name) {
+          case "byteCol":
+            return (T) new ColumnName("data_transfer_size");
+          case "timeCol":
+            return (T) new ColumnName("response_time");
+          case "outputSizeCol":
+            return (T) new Text("total_size_mb");
+          case "outputTimeCol":
+            return (T) new Text("total_time_sec");
+        }
+        return null;
+      }
+
+      @Override
+      public int size() {
+        return 4;
+      }
+
+      @Override
+      public boolean contains(String name) {
+        return true;
+      }
+
+      @Override
+      public TokenType type(String name) {
+        return null;
+      }
+
+      @Override
+      public int line() {
+        return 1;
+      }
+
+      @Override
+      public int column() {
+        return 0;
+      }
+
+      @Override
+      public String source() {
+        return "aggregate-stats :data_transfer_size :response_time total_size_mb total_time_sec";
+      }
+
+      @Override
+      public JsonElement toJson() {
+        return null;
+      }
+    };
+  }
+}

--- a/wrangler-docs/directives/parse-as-bytesize.md
+++ b/wrangler-docs/directives/parse-as-bytesize.md
@@ -1,0 +1,17 @@
+# Parse as ByteSize
+
+The PARSE-AS-BYTESIZE directive parses a string representation of byte size into a numeric value.
+
+## Syntax
+```
+parse-as-bytesize <column>
+```
+
+## Usage Notes
+
+The PARSE-AS-BYTESIZE directive will parse strings representing byte sizes (e.g., "10KB", "5MB") into numeric values in bytes. The column to be parsed should be of type string.
+
+If the column is `null` or is already a numeric field, applying this directive is a no-op.
+
+## Examples
+Input: "10KB" → Output: 10240 (bytes)

--- a/wrangler-docs/directives/parse-as-timeduration.md
+++ b/wrangler-docs/directives/parse-as-timeduration.md
@@ -1,0 +1,17 @@
+# Parse as TimeDuration
+
+The PARSE-AS-TIMEDURATION directive parses a string representation of time duration into a numeric value.
+
+## Syntax
+```
+parse-as-timeduration <column>
+```
+
+## Usage Notes
+
+The PARSE-AS-TIMEDURATION directive will parse strings representing time durations (e.g., "2h", "30m") into numeric values in milliseconds. The column to be parsed should be of type string.
+
+If the column is `null` or is already a numeric field, applying this directive is a no-op.
+
+## Examples
+Input: "2h" → Output: 7200000 (milliseconds)


### PR DESCRIPTION
# Enhancing Wrangler with Byte Size and Time Duration Support

## Overview
This enhancement introduces native support for handling byte sizes (e.g., KB, MB) and time durations (e.g., ms, sec) in the CDAP Wrangler library. It simplifies the process for users to parse, aggregate, and manage data representing sizes and time intervals within their recipes.

## Features
### Key Enhancements
1. **New Lexer Tokens**:
   - `BYTE_SIZE` and `TIME_DURATION` added to the grammar for seamless parsing of size and time values.

2. **New Directives**:
   - **Parse as ByteSize**: Parses size-related values (e.g., "2 MB", "1024 KB").
   - **Parse as TimeDuration**: Parses time-related values (e.g., "500 ms", "2 sec").

3. **AggregateStats Directive**:
   - Aggregates statistics based on the new types, enabling operations like summing byte sizes or calculating durations.

4. **Improved Parsing Logic**:
   - Refactored logic for better error handling and compatibility for parsing `ByteSize` and `TimeDuration`.

5. **Updated Grammar Rules**:
   - Enhanced the parsing logic in `ConvertString.java` to support additional whitespace symbols, improving flexibility and robustness.

6. **Maven Configuration Updates**:
   - Added `maven-surefire-plugin` configuration to allow reflective access during testing.

### Documentation
- Comprehensive usage examples for the new directives (`Parse as ByteSize`, `Parse as TimeDuration`, and `AggregateStats`) added to the project documentation.

### Testing
- Added unit tests for:
  - `ByteSize` and `TimeDuration` parsing logic to validate correct handling of size and time values.
  - `AggregateStats` directive to ensure proper aggregation of statistics.
  - Edge cases and error scenarios for improved robustness.

### Additional Improvements
- Updated `pom.xml` to include necessary dependencies and configurations.

## Benefits
- Simplifies workflows by eliminating manual calculations for sizes and durations.
- Provides robust and reusable directives for common operations involving size and time data.
- Ensures consistency and reduces complexity in multi-step recipes.
- Improves parsing flexibility with enhanced grammar rules.
- Streamlines testing with updated Maven configurations.
